### PR TITLE
Add ARM64 target architecture to CI/CD pipeline

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -118,4 +118,4 @@ jobs:
             dungeonclub-windows.zip
             dungeonclub-macos.zip
             dungeonclub-linux.tgz
-            dungeonclub-linux-arm.tgz
+            dungeonclub-linux-arm.zip

--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -14,6 +14,9 @@ jobs:
           - runs-on: windows-latest
             artifact: windows
             binary-name: server.exe
+          - runs-on: ubuntu-24.04-arm
+            artifact: linux_arm64
+            binary-name: server
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
@@ -72,6 +75,7 @@ jobs:
 
       - run: rm build/server
       - run: cp -r build/. build_macos
+      - run: cp -r build/. build_linux_arm
 
       - name: Download Windows server
         uses: actions/download-artifact@v3
@@ -93,6 +97,17 @@ jobs:
       - name: Compress MacOS build
         run: cd build_macos; zip -r ../dungeonclub-macos.zip *; cd ..
 
+      - name: Download Linux (ARM64) server
+        uses: actions/download-artifact@v3
+        with:
+          name: server_linux_arm64
+          path: build_linux_arm
+
+      - run: chmod +x build_linux_arm/server
+
+      - name: Compress Linux (ARM64) build
+        run: cd build_linux_arm; zip -r ../dungeonclub-linux-arm.zip *; cd ..
+
       - run: mv build.tgz dungeonclub-linux.tgz
 
       - name: Create Release
@@ -103,3 +118,4 @@ jobs:
             dungeonclub-windows.zip
             dungeonclub-macos.zip
             dungeonclub-linux.tgz
+            dungeonclub-linux-arm.tgz

--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -19,8 +19,8 @@ jobs:
             binary-name: server
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dart-lang/setup-dart@v1.4
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1.7.1
 
       - name: Install dependencies
         run: dart pub get
@@ -29,7 +29,7 @@ jobs:
         run: dart bin/build.dart --part server
 
       - name: Upload as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: server_${{ matrix.artifact }}
           path: build/latest/${{ matrix.binary-name }}
@@ -38,8 +38,8 @@ jobs:
     name: Build All (Linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dart-lang/setup-dart@v1.5.0
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1.7.1
 
       - name: Install dependencies
         run: dart pub get
@@ -51,7 +51,7 @@ jobs:
         run: find build/latest -printf "%P\n" | tar -czf build.tgz --no-recursion -C build/latest -T -
 
       - name: Upload as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: all_linux
           path: build.tgz
@@ -65,7 +65,7 @@ jobs:
         run: sudo apt-get install -y zip
 
       - name: Download Linux build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: all_linux
 
@@ -78,7 +78,7 @@ jobs:
       - run: cp -r build/. build_linux_arm
 
       - name: Download Windows server
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: server_windows
           path: build
@@ -87,7 +87,7 @@ jobs:
         run: cd build; zip -r ../dungeonclub-windows.zip *; cd ..
 
       - name: Download MacOS server
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: server_macos
           path: build_macos
@@ -98,7 +98,7 @@ jobs:
         run: cd build_macos; zip -r ../dungeonclub-macos.zip *; cd ..
 
       - name: Download Linux (ARM64) server
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: server_linux_arm64
           path: build_linux_arm
@@ -111,7 +111,7 @@ jobs:
       - run: mv build.tgz dungeonclub-linux.tgz
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.3.2
         with:
           draft: true
           files: |

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,15 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.2"
+    version: "67.0.0"
   ambience:
     dependency: "direct main"
     description:
@@ -27,10 +22,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.4.1"
   archive:
     dependency: "direct main"
     description:
@@ -99,10 +94,10 @@ packages:
     dependency: transitive
     description:
       name: build_modules
-      sha256: "403ba034d94f1a0f26362fe14fd83e9ff33644f5cbe879982920e3d209650b43"
+      sha256: b1fc29a603669b25a5d95cc9610ed649e9f00e6075e5b6b721aa1a095cff13de
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.9"
+    version: "5.0.13"
   build_resolvers:
     dependency: transitive
     description:
@@ -131,10 +126,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      sha256: e8d818410cc8b4dc96c4960ce0ab84fe3f2b0ca6576cc130fd7277b56eba9d68
+      sha256: f9b8e84dbfa7688221c2376e6f68ffd796597785a0a5b1e8cd2516a92fdc0a3c
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.11"
+    version: "4.1.5"
   built_collection:
     dependency: transitive
     description:
@@ -392,14 +387,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2-main.4"
   mailer:
     dependency: "direct main"
     description:
@@ -763,4 +750,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-259.0.dev <3.7.0"
+  dart: ">=3.7.0 <3.9.0-z"


### PR DESCRIPTION
This PR upgrades all used actions in the GitHub CI/CD workflow and introduces ARM64 as a target architecture. The `ubuntu-24.04-arm` GitHub runner image is used to perform native compilation.

It's worth noting that Dart does support some [cross-compilation as of version 3.8](https://dart.dev/tools/dart-compile#cross-compilation-exe), but cross-compiled executables unfortunately yield file sizes of ~70MB. By natively compiling on an ARM64 machine, the `server` executable lands at ~10MB.